### PR TITLE
Added Arch Linux AUR steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ sudo apt install \
 >Debian and Kubuntu doesn't support KDE Plasma 6 yet. 
 >It can be available on Debian 13 (Trixie) and Kubuntu 24.10 (Oracular Oriole).
 
+#### 5\. Arch Linux
+
+The package is available to be installed from the Arch Linux AUR.
+
+https://aur.archlinux.org/packages/vinyl
+
+You can use your favorite Arch AUR helper to install it.
+
+Example.
+
+```shell
+yay -S vinyl
+```
 
 ### Building the source
 


### PR DESCRIPTION
I maintain the lightly-qt6 package on the AUR.
The package for this theme was not available so i've added it over there.

To validate I have tested installation first inside a Arch Linux Docker container and then inside a VM running Plasma 6.
Both succeeded.

https://aur.archlinux.org/packages/vinyl

Hopefully it'll help folks out who use Arch Linux and wish to install this theme on Plasma 6.