### PR TITLE
Drag and drop mode changes

### DIFF
--- a/kstyle/vinyl.kcfg
+++ b/kstyle/vinyl.kcfg
@@ -184,7 +184,7 @@
           <choice name="WD_MINIMAL" />
           <choice name="WD_FULL" />
       </choices>
-      <default>WD_FULL</default>
+      <default>WD_MINIMAL</default>
     </entry>
 
     <!--

--- a/kstyle/vinylwindowmanager.h
+++ b/kstyle/vinylwindowmanager.h
@@ -171,7 +171,7 @@ namespace Vinyl
         void resetDrag();
 
         //* start drag
-        void startDrag( QWindow*, const QPoint& );
+        void startDrag( QWindow*);
 
         //* X11 specific implementation for startDrag
         void startDragX11( QWindow*, const QPoint& );
@@ -292,6 +292,13 @@ namespace Vinyl
 
         //* true if drag is locked
         bool _locked = false;
+
+        //* true if the event we are intercepting passed through a QQuickWidget.
+        /**In this case we shouldn't start a drag, because if it was to start, we would have done it in the event filter of a qquickwidget.
+        * Event handlers don't accept input events, but they do block QQuickItems to receive the event, so the event may have been
+        * managed by an handler and not blocked by the root qml item.
+        **/
+        bool _eventInQQuickWidget = false;
 
         //* cursor override
         /** used to keep track of application cursor being overridden when dragging in non-WM mode */


### PR DESCRIPTION
Potential fix for #37

I tested the changes inside a Wayland session only.

Tested the following cases:

- Dolphin drag the window from the toolbar also moves the window as expected.
- Systemsettings drag the window from the toolbar also same behavior.

These changes come directly from Breeze.

- https://invent.kde.org/plasma/breeze/-/merge_requests/84
- https://invent.kde.org/plasma/breeze/-/merge_requests/468

