### PR TITLE
DBus exec changes to use org.kde.plasma.workspace.dbus

### DIFF
--- a/launcher/src/package/contents/ui/ButtonGroup.qml
+++ b/launcher/src/package/contents/ui/ButtonGroup.qml
@@ -110,7 +110,8 @@ Rectangle {
                     buttonTooltip.visible = false
                 }
                 onClicked: {
-                    executable.exec(command)
+			        //executable.exec(command)
+			        root.dbusAsyncCall(service, path, member)
                 }
             }
         }

--- a/launcher/src/package/contents/ui/VinylMenuLauncher.qml
+++ b/launcher/src/package/contents/ui/VinylMenuLauncher.qml
@@ -16,7 +16,7 @@ import org.kde.plasma.plasmoid
 
 import org.kde.plasma.private.kicker as Kicker
 //import org.kde.plasma.private.quicklaunch
-
+import org.kde.plasma.workspace.dbus as DBus // Needed to call DBus methods
 import org.kde.plasma.plasma5support as P5Support // Needed by datasource
 
 Item {
@@ -83,6 +83,8 @@ Item {
         property int layoutFixedHeight: (cellSize * (numberRows + 2)) +
                                         (2.0 * Kirigami.Units.largeSpacing)
 
+        // catch dbus reply
+        property DBus.DBusPendingReply pendingReply
 
         // Events
         onVisibleChanged: {
@@ -191,6 +193,14 @@ Item {
 
         function toggle() {
             root.visible = !root.visible;
+        }
+
+        function dbusAsyncCall(service, path, member) {
+            root.pendingReply = DBus.SessionBus.asyncCall({
+                "service": service,
+                "path": path,
+                "member": member
+            });
         }
 
         FocusScope {
@@ -448,12 +458,18 @@ Item {
                         ListElement {
                             description: QT_TR_NOOP("Shows session exit screen")
                             icon:    "arrow-left"
-                            command: "qdbus-qt6 org.kde.LogoutPrompt /LogoutPrompt promptAll"
+                            //command: "qdbus-qt6 org.kde.LogoutPrompt /LogoutPrompt promptAll"
+                            service: "org.kde.LogoutPrompt"
+                            path: "/LogoutPrompt"
+                            member: "promptAll"
                         }
                         ListElement {
                             description: QT_TR_NOOP("Lock screen")
                             icon: "lock"
-                            command: "qdbus-qt6 org.kde.screensaver /ScreenSaver Lock"
+                            //command: "qdbus-qt6 org.kde.screensaver /ScreenSaver Lock"
+                            service: "org.kde.screensaver"
+                            path: "/ScreenSaver"
+                            member: "Lock"
                         }
                         /*ListElement {
                             description: QT_TR_NOOP("Open Krunner dialog")


### PR DESCRIPTION
I am sure there could be improvements to be made here.
It moves the code away from relying on using `qdbus-qt6`
Distributions I have tested on Archlinux, Fedora, openSuse TW and Neon and it works.

In https://discuss.kde.org/t/communicate-with-plasmoid/28271/9 - one of the Plasma devs mentioned https://invent.kde.org/plasma/plasma-workspace/-/tree/master/components/dbus?ref_type=heads

Then I saw https://invent.kde.org/plasma/plasma-workspace/-/blob/master/components/dbus/autotests/dbusmethodcalltest.qml?ref_type=heads and used the asyncall as an example. You can also validate the response capture inside `root.pendingReply` if required.

Not sure if there are further changes required in any CMakefiles.

#47 