### PR TITLE
Archlinux AUR package name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,19 +59,21 @@ sudo rpm-ostree install --apply-live vinyl-theme
 
 The package is available to be installed from the Arch Linux AUR.
 
-https://aur.archlinux.org/packages/vinyl-git
+https://aur.archlinux.org/packages/vinyl
+
+This package uses the viny-theme code from the latest release tag.
 
 You can use your favorite Arch AUR helper to install it.
 Example:
 
 ```shell
 yay -Syu
-yay -S --nedded base-devel vinyl-git
+yay -S --needed base-devel vinyl
 ```
 > [!NOTE]
 > Please do not report any issues with the AUR package in this repository.
 
-Instead either use the AUR comment system / https://github.com/DeltaCopy/vinyl-git-aur/issues
+Instead either use the AUR comment system / https://github.com/DeltaCopy/vinyl-aur-ci/issues
 
 
 ## Building from source (manual build)


### PR DESCRIPTION
As we are now having consistent release tags, along with versions being identified inside the application style configuration page, I have disowned the original `vinyl-git` package which was going to the head commit of the main branch.

The package `vinyl` now points to the release tarball as source. It makes maintaining the package easier and package updates are fully automated using the scheduled CI pipeline setup in https://github.com/DeltaCopy/vinyl-aur-ci

On a separate note, I have made some good progress with the GH workflow automation which generates pre-built packages across various distributions. There is a long term plan to have a similar setup as darkly whereby there are 2 packages: `vinyl` and `vinyl-bin` the latter will point to the pre-built zst asset generated via the GH workflow.

