### PR TITLE
Add NixOS flake + install instructions for NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,39 @@ sudo apk -U add 'build-base' 'kconfigwidgets-dev' 'kdecoration-dev' 'kguiaddons-
   'py3-cairosvg'
 ```
 
+#### 6\. NixOS
+
+Add the repo as a flake input:
+
+```nix
+inputs = {
+  vinyl-theme = {
+    url = "github:ekaaty/vinyl-theme";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+};
+```
+
+And add it as a nixpkgs overlay:
+
+```nix
+outputs = { nixpkgs, vinyl-theme, ... }: {
+  nixosConfigurations.my-nixos = nixpkgs.lib.nixosSystem {
+    modules = [
+      vinyl-theme.nixosModules.nixpkgs-overlay
+      ./configuration.nix
+    ]
+  }
+}
+
+# configuration.nix:
+{
+  environment.systemPackages = [
+    pkgs.vinyl-theme
+  ];
+}
+```
+
 ### Building the source
 
 To build the code, do the following:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1765779637,
+        "narHash": "sha256-KJ2wa/BLSrTqDjbfyNx70ov/HdgNBCBBSQP3BIzKnv4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1306659b587dc277866c7b69eb97e5f07864d8c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "A theme for KDE Plasma";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self, nixpkgs, ... }@inputs:
+    {
+      overlays.default = final: prev: {
+        vinyl-theme = prev.callPackage ./package.nix { };
+      };
+
+      nixosModules.nixpkgs-overlay = inputs: {
+        nixpkgs.overlays = [
+          self.overlays.default
+        ];
+      };
+    }
+    // (inputs.utils.lib.eachSystem
+      [
+        "x86_64-linux"
+        "aarch64-linux"
+      ]
+      (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+        in
+        rec {
+          packages = rec {
+            default = vinyl-theme;
+            vinyl-theme = pkgs.callPackage ./package.nix { };
+          };
+
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [ packages.default ];
+          };
+        }
+      )
+    );
+}

--- a/icons/src/places/scalable/links.txt
+++ b/icons/src/places/scalable/links.txt
@@ -23,4 +23,3 @@ folder-temp.svg ./folder-recent.svg
 folder-text.svg ./folder-txt.svg
 folder-videos.svg ./folder-video.svg
 network-workgroup.svg ./network-server.svg
-start-here-kde.svg ./start-here-kde-plasma.svg

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  extra-cmake-modules,
+  gettext,
+  kdePackages,
+  python3,
+  python3Packages,
+  qt6Packages,
+  xorg,
+}:
+stdenv.mkDerivation {
+  pname = "vinyl-theme";
+  version = (lib.strings.trim (builtins.readFile ./VERSION));
+
+  outputs = [
+    "out"
+  ];
+
+  src = ./.;
+
+  preBuild = ''
+    # Cursors are rendered from SVG to PNG using cairosvg, which uses Fontconfig.
+    # Fontconfig complains about there being no writable cache directories.
+    export XDG_CACHE_HOME=$PWD/cache;
+  '';
+
+  postPatch = ''
+    patchShebangs --build .
+
+    # Ensure PROJECT_DATE cmake variable is not based on commit metadata.
+    declare -a cmakeListsDeclaringProjectDate
+    readarray -t cmakeListsDeclaringProjectDate < <(
+      find -type f -iname CMakeLists.txt \
+        | xargs grep -l 'OUTPUT_VARIABLE PROJECT_DATE'
+    )
+
+    substituteInPlace "''${cmakeListsDeclaringProjectDate[@]}" \
+      --replace-fail '"date +%y.%1m.%1d -d \"$(git log -n 1 --pretty=format:%cD 2>/dev/null)\""' "\"echo 1970.01.01\""
+  '';
+
+  nativeBuildInputs = [
+    # Build system.
+    cmake
+    extra-cmake-modules
+    kdePackages.extra-cmake-modules
+    gettext
+
+    # Cursors.
+    python3
+    python3Packages.cairosvg
+    python3Packages.lxml
+    xorg.xcursorgen
+
+    # Hooks.
+    qt6Packages.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    kdePackages.frameworkintegration
+    kdePackages.kcmutils
+    kdePackages.kcolorscheme
+    kdePackages.kconfig
+    kdePackages.kconfigwidgets
+    kdePackages.kcoreaddons
+    kdePackages.kdecoration
+    kdePackages.kguiaddons
+    kdePackages.ki18n
+    kdePackages.kiconthemes
+    kdePackages.kirigami
+    kdePackages.kpackage
+    kdePackages.kservice
+    kdePackages.kwayland
+    kdePackages.kwindowsystem
+    kdePackages.libplasma
+    qt6Packages.qtbase
+    qt6Packages.qtdeclarative
+    qt6Packages.qtsvg
+    xorg.libX11
+  ];
+
+  meta = {
+    description = "A theme for KDE Plasma";
+    homepage = "https://github.com/ekaaty/vinyl-theme";
+    license = with lib.licenses; [
+      gpl2
+      mit
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Great work on the vinyl theme! I found it a few months ago, and I've been daily driving it since.

I use NixOS for my distro, and due to the way the package manager works on the system, I had to [package](https://github.com/eth-p/my-nixos/blob/6064c134fe3384c5d7129249b76c01a896b401d3/packages/vinyl-theme/package.nix) it for nix before I could install it. It takes a bit of trial and error to do, and it's not as simple as the other available installation methods for vinyl. I felt it might help encourage other NixOS users to try the theme if it was easier to install, so I figured I would create this PR to help with that.

Ideally, I would have just added the package on the official NixOS nixpkgs repo, but their [package guidelines](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#quick-start-to-adding-a-package) suggest that vinyl-theme is just a little bit too niche right now to be accepted:

> Before adding a new package, please consider the following questions:
> * [...]
> * How realistic is it that it will be used by other people? It's good that nixpkgs caters to various niches, but if it's a niche of 5 people it's probably too small. A good estimate is checking upstream issues and pull requests, or other software repositories. 

As a compromise, I added the package info (`flake.nix`, `package.nix`) directly to the repo here, similar to how other projects like [vicinae](https://github.com/vicinaehq/vicinae/blob/main/flake.nix) and [kwin-effects-better-blur-dx](https://github.com/xarblu/kwin-effects-better-blur-dx/blob/main/flake.nix) do it.

If you feel that it's too invasive to include the nix packaging within the vinyl-theme repo itself, no worries, just close this PR.